### PR TITLE
Added conditional OBJC lang support only for macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,12 @@ jobs:
             cxx: clang++
           - os: windows-latest
             platform: windows
-            cc: cl
-            cxx: cl
     
     env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
       BUILD_TYPE: ${{ matrix.build_type }}
       PLATFORM: ${{ matrix.platform }}
+      CC: ${{ matrix.os != 'windows-latest' && matrix.cc || '' }}
+      CXX: ${{ matrix.os != 'windows-latest' && matrix.cxx || '' }}
     
     steps:
     - name: Checkout code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.15)
-project(ggml-viz VERSION 0.1 LANGUAGES C CXX OBJC)
+
+# Set languages based on platform
+if(APPLE)
+    project(ggml-viz VERSION 0.1 LANGUAGES C CXX OBJC)
+else()
+    project(ggml-viz VERSION 0.1 LANGUAGES C CXX)
+endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Enforce C++17

--- a/examples/llama_demo/CMakeLists.txt
+++ b/examples/llama_demo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # examples/llama_demo/CMakeLists.txt
+cmake_minimum_required(VERSION 3.15)
 
 # Build llama.cpp first
 add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/llama.cpp 

--- a/examples/whisper_demo/CMakeLists.txt
+++ b/examples/whisper_demo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # examples/whisper_demo/CMakeLists.txt
+cmake_minimum_required(VERSION 3.15)
 
 # Create whisper demo executable (placeholder implementation)
 add_executable(run_whisper_vis

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # src/CMakeLists.txt
+cmake_minimum_required(VERSION 3.15)
 project(ggml_viz_instrumentation)
 
 # Add IPC library for cross-platform shared memory

--- a/src/plugins/plugins_api.hpp
+++ b/src/plugins/plugins_api.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+// Plugin API definitions - placeholder for future implementation

--- a/src/server/data_structs.hpp
+++ b/src/server/data_structs.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+// Server data structures - placeholder for future implementation

--- a/src/server/server_core.hpp
+++ b/src/server/server_core.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+// Server core implementation - placeholder for future implementation

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,4 +1,5 @@
 # third_party/CMakeLists.txt
+cmake_minimum_required(VERSION 3.15)
 
 # GLFW Configuration
 set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
Added conditional OBJC language support only for macOS builds since we have Objective-C source files (src/instrumentation/sched_interpose.mm) that are only needed on macOS.
Removed cc: cl and cxx: cl from Windows matrix and made CC/CXX environment variables conditional so they're only set for non-Windows platforms.
Fixed key issues including:
    - Added include guards (#pragma once) to missing header files
    - Added cmake_minimum_required(VERSION 3.15) to project CMakeLists.txt files