### PR TITLE
Added missing #include <memory> to logger.hpp for linux build error, …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ endif()
 target_include_directories(ggml_viz_hook
     PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR}/instrumentation
+      ${CMAKE_CURRENT_SOURCE_DIR}
       ${CMAKE_SOURCE_DIR}/third_party/ggml/include
       ${CMAKE_SOURCE_DIR}/third_party/ggml/src        # for ggml-impl.h
 )
@@ -135,6 +136,11 @@ target_compile_definitions(ggml_viz_hook
       GGML_VIZ_SHARED_BUILD
     PRIVATE
       BUILDING_GGML_VIZ
+)
+
+# Add logger sources directly to ggml_viz_hook to avoid circular dependency
+target_sources(ggml_viz_hook PRIVATE 
+    utils/logger.cpp
 )
 
 target_link_libraries(ggml_viz_hook

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -65,7 +65,7 @@ void Logger::configure_from_env() {
         } else if (level_str == "WARN" || level_str == "warn") {
             current_level_ = LogLevel::WARN;
         } else if (level_str == "ERROR" || level_str == "error") {
-            current_level_ = LogLevel::ERROR;
+            current_level_ = LogLevel::ERROR_LEVEL;
         } else if (level_str == "FATAL" || level_str == "fatal") {
             current_level_ = LogLevel::FATAL;
         }
@@ -99,7 +99,7 @@ std::string Logger::level_to_string(LogLevel level) const {
         case LogLevel::DEBUG: return "DEBUG";
         case LogLevel::INFO:  return "INFO";
         case LogLevel::WARN:  return "WARN";
-        case LogLevel::ERROR: return "ERROR";
+        case LogLevel::ERROR_LEVEL: return "ERROR";
         case LogLevel::FATAL: return "FATAL";
         default: return "UNKNOWN";
     }
@@ -154,7 +154,7 @@ void Logger::log(LogLevel level, const std::string& message) {
     oss << message;
     
     // Output to appropriate stream
-    if (level >= LogLevel::ERROR) {
+    if (level >= LogLevel::ERROR_LEVEL) {
         std::cerr << oss.str() << std::endl;
     } else {
         std::cout << oss.str() << std::endl;
@@ -174,7 +174,7 @@ void Logger::warn(const std::string& message) {
 }
 
 void Logger::error(const std::string& message) {
-    log(LogLevel::ERROR, message);
+    log(LogLevel::ERROR_LEVEL, message);
 }
 
 void Logger::fatal(const std::string& message) {
@@ -205,7 +205,7 @@ Logger::LogStream Logger::warn_stream() {
 }
 
 Logger::LogStream Logger::error_stream() {
-    return LogStream(*this, LogLevel::ERROR);
+    return LogStream(*this, LogLevel::ERROR_LEVEL);
 }
 
 Logger::LogStream Logger::fatal_stream() {

--- a/src/utils/logger.hpp
+++ b/src/utils/logger.hpp
@@ -1,6 +1,17 @@
 // src/utils/logger.hpp
 #pragma once
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#undef ERROR  // Windows defines ERROR as a macro, which conflicts with our enum
+#endif
+
 #include <string>
 #include <iostream>
 #include <mutex>
@@ -14,11 +25,11 @@ namespace ggml_viz {
 /**
  * Log levels in order of severity
  */
-enum class LogLevel {
+enum class LogLevel : int {
     DEBUG = 0,    // Detailed debug information
     INFO = 1,     // General information  
     WARN = 2,     // Warning messages
-    ERROR = 3,    // Error messages
+    ERROR_LEVEL = 3,    // Error messages (renamed to avoid Windows ERROR macro conflict)
     FATAL = 4     // Fatal errors
 };
 
@@ -102,8 +113,8 @@ public:
 
     template<typename... Args>
     void error(const std::string& format, Args... args) {
-        if (should_log(LogLevel::ERROR)) {
-            log(LogLevel::ERROR, format_string(format, args...));
+        if (should_log(LogLevel::ERROR_LEVEL)) {
+            log(LogLevel::ERROR_LEVEL, format_string(format, args...));
         }
     }
 

--- a/src/utils/logger.hpp
+++ b/src/utils/logger.hpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <iomanip>
 #include <sstream>
+#include <memory>
 
 namespace ggml_viz {
 


### PR DESCRIPTION
…added utils/logger.cpp directly to ggml_viz_hook sources and current source dir to include paths for windows build error, fixed linking dependencies